### PR TITLE
Compatibility with Python 3 and pyScss 1.2.

### DIFF
--- a/pyramid_scss/__init__.py
+++ b/pyramid_scss/__init__.py
@@ -1,7 +1,7 @@
 import os
 import logging
 
-from zope.interface import implements
+from zope.interface import implementer
 from zope.interface import Interface
 
 from pyramid.interfaces import ITemplateRenderer
@@ -60,8 +60,8 @@ def renderer_factory(info):
     options = dict((k, asbool(v)) for k, v in options.items())
     return ScssRenderer(info, options)
 
+@implementer(ITemplateRenderer)
 class ScssRenderer(object):
-    implements(ITemplateRenderer)
     cache = None
 
     def __init__(self, info, options):

--- a/pyramid_scss/tests/__init__.py
+++ b/pyramid_scss/tests/__init__.py
@@ -34,7 +34,11 @@ class PyramidScssTestCase(TestCase):
         fixture_path = abspath_from_asset_spec('pyramid_scss.tests:fixtures')
         for path, dirs, files in os.walk(fixture_path):
             for name in files:
-                with open(os.path.join(path, name)) as f:
+                if name.endswith('.png'):
+                    mode = 'rb'
+                else:
+                    mode = 'r'
+                with open(os.path.join(path, name), mode) as f:
                     self.fixtures.setdefault(name, f.read())
 
 

--- a/pyramid_scss/tests/fixtures/test_compress.css
+++ b/pyramid_scss/tests/fixtures/test_compress.css
@@ -1,1 +1,1 @@
-#test_scss p{color:#fc0}#test_scss a{color:#00f}
+#test_scss p{color:#fc0}#test_scss a{color:blue}

--- a/pyramid_scss/tests/fixtures/test_nocompress.css
+++ b/pyramid_scss/tests/fixtures/test_nocompress.css
@@ -1,6 +1,4 @@
 #test_scss p {
-  color: #fc0;
-}
-#test_scss a {
-  color: #0000ff;
-}
+  color: #fc0; }
+  #test_scss a {
+    color: blue; }

--- a/pyramid_scss/tests/test_cache.py
+++ b/pyramid_scss/tests/test_cache.py
@@ -7,7 +7,7 @@ import pyramid_scss.controller as controller
 class CacheTestCase(PyramidScssTestCase):
     @staticmethod
     def generate_id(count):
-        return ''.join(random.choice(string.ascii_uppercase + string.lowercase + string.digits) for i in range(count))
+        return ''.join(random.choice(string.ascii_letters + string.digits) for i in range(count))
 
     def test_cache(self):
         self.renderer.options.update({

--- a/pyramid_scss/tests/test_renderer.py
+++ b/pyramid_scss/tests/test_renderer.py
@@ -4,7 +4,7 @@ import pyramid_scss.controller as controller
 class RendererTestCase(PyramidScssTestCase):
     def test_nocompress(self):
         self.renderer.options.update({
-            'compress': False
+            'style': 'nested'
         })
 
         request = DummyRequest(self.config.registry)
@@ -17,7 +17,7 @@ class RendererTestCase(PyramidScssTestCase):
 
     def test_compress(self):
         self.renderer.options.update({
-            'compress': True
+            'style': 'compressed'
         })
 
         request = DummyRequest(self.config.registry)
@@ -39,7 +39,7 @@ class RendererTestCase(PyramidScssTestCase):
 
     def test_spritemap(self):
         self.renderer.options.update({
-            'compress': True
+            'style': 'compressed'
         })
 
         request = DummyRequest(self.config.registry)

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,7 @@ changes = open(os.path.join(here, 'CHANGES.rst'), 'r').read()
 requires = [
     'pyramid',
     'zope.interface',
-    'pyScss>=1.1.5',
-    'PIL',
+    'pyScss>=1.2',
 ]
 
 setup(


### PR DESCRIPTION
- `implements()` doesn't work in Python 3
- Files are opened as UTF-8 by default, so reading from a PNG requires binary mode
- `string.lowercase` is no more
- `compress` has changed to `style` to match the Ruby implementation

Incidentally, if you don't have time to maintain this library, I'd be willing to do so; I did most of the work on pyScss 1.2 and use it with this lib for several projects.
