### PR TITLE
Adds static route shadowing capability

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,13 @@ Second, assuming you are using URL dispatch, add a route to serve css::
     config.add_route('css', '/css/{css_path:.*}.css')
     config.add_view(route_name='css', view='pyramid_scss.controller.get_scss', renderer='scss', request_method='GET')
 
+Alternatively, you can configure ``pyramid_scss`` to shadow a path which already contains static assets, and default to a ``static_view`` if no SCSS stylesheet matches the request. In your ``project.ini``::
+
+    scss.static_route =
+        css = project:assets/css/
+
+With this configuration, a request for ``/css/style.css`` will first look for ``style.scss`` in ``scss.asset_path`` and if it's not found, then a ``static_view`` for ``project:assets/css/`` will be consulted. If you have this configuration, then you can generate a route for a static asset with ``static_url`` and those requests will transparently map to SCSS stylesheets.
+
 *TODO:* Add a traversal example.
 
 In the example above, an SCSS stylesheet located at ``myproject/assets/scss/style.scss`` (using the ``asset_path`` configured in the Configuration section) could be accessed by a URL request to ``http://myproject/css/style.css``. This route would also resolve stylesheets in subdirectories of ``asset_path``.

--- a/pyramid_scss/__init__.py
+++ b/pyramid_scss/__init__.py
@@ -122,7 +122,9 @@ def includeme(config):
 
             def register_static_route(route_name, spec):
                 Logger.debug('registering static route {}: {}'.format(route_name, spec))
-                config.registry._static_url_registrations.append((None, spec, route_name))
+                # TODO: fourth value here is `cachebust`, what does it do? see:
+                # /home/ubuntu/.virtualenvs/boutique/local/lib/python2.7/site-packages/pyramid-1.6a2-py2.7.egg/pyramid/config/views.py(1971)generate()
+                config.registry._static_url_registrations.append((None, spec, route_name, None))
 
             config.action('scss_register_static_route_{}'.format(name), register_static_route,
                           args=(route_name, static_spec))

--- a/pyramid_scss/controller.py
+++ b/pyramid_scss/controller.py
@@ -13,6 +13,37 @@ from pyramid.static import static_view
 Logger = logging.getLogger('pyramid_scss')
 
 
+class SCSSController(object):
+    def __init__(self, base_path):
+        self.base_path = base_path.strip()
+
+    def __call__(self, context, request):
+        subpath = '/'.join(request.subpath)
+        scss = self._load_asset(subpath)
+
+        if scss is None:
+            raise HTTPNotFound()
+
+        Logger.info('serving SCSS request for %s', request.matchdict.get('css_path', request.subpath))
+        return scss
+
+    def _get_asset_path(self, css_path):
+        if css_path.endswith('.css'):
+            css_path = css_path.rsplit('.css')[0]
+
+        filename = css_path + u'.scss'
+        return abspath_from_asset_spec(os.path.join(self.base_path, filename))
+
+    def _load_asset(self, path):
+        path = self._get_asset_path(path)
+
+        if os.path.exists(path):
+            with open(path) as f:
+                return f.read()
+
+        return None
+
+
 def get_scss(root, request):
     Logger.info('serving SCSS request for %s', request.matchdict.get('css_path'))
     scss = _load_asset(request)
@@ -37,7 +68,7 @@ def _get_asset_path(request):
 
     filename = css_path + u'.scss'
     paths = []
-    for s in request.registry.settings.get('scss.asset_path').split('\n'):
+    for s in request.registry.settings.get('scss.asset_path').strip().splitlines():
         if s:
             p = abspath_from_asset_spec(os.path.join(s.strip(), filename))
             paths.append(p)
@@ -57,16 +88,16 @@ def _load_asset(request):
 
 
 class scss_static_view(object):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, scss_spec, static_spec, *args, **kwargs):
         kwargs['use_subpath'] = True
-        self.static_view = static_view(*args, **kwargs)
+        self.static_view = static_view(static_spec, *args, **kwargs)
+        self.scss_view = SCSSController(scss_spec)
 
     def __call__(self, context, request):
         try:
             render = get_renderer('scss')
             system = dict(request=request)
-            return Response(render(get_scss(context, request), system),
-                            content_type='text/css',
-                            status='200 OK')
+            return Response(render(self.scss_view(context, request), system),
+                            content_type='text/css', status='200 OK')
         except HTTPNotFound:
             return self.static_view(context, request)

--- a/pyramid_scss/controller.py
+++ b/pyramid_scss/controller.py
@@ -1,11 +1,17 @@
 import os
 import logging
+from collections import Sequence
 
 from pyramid.exceptions import ConfigurationError
 from pyramid.httpexceptions import HTTPNotFound
+from pyramid.renderers import get_renderer
+from pyramid.response import Response
 from pyramid.resource import abspath_from_asset_spec
+from pyramid.static import static_view
+
 
 Logger = logging.getLogger('pyramid_scss')
+
 
 def get_scss(root, request):
     Logger.info('serving SCSS request for %s', request.matchdict.get('css_path'))
@@ -16,11 +22,20 @@ def get_scss(root, request):
 
     return scss
 
+
 def _get_asset_path(request):
     if 'scss.asset_path' not in request.registry.settings:
         raise ConfigurationError('SCSS renderer requires ``scss.asset_path`` setting')
 
-    filename = request.matchdict.get('css_path') + '.scss'
+    css_path = request.matchdict.get('css_path', request.subpath)
+
+    if isinstance(css_path, Sequence) and not isinstance(css_path, basestring):
+        css_path = u'/'.join(css_path)
+
+    if css_path.endswith('.css'):
+        css_path = css_path.rsplit('.css')[0]
+
+    filename = css_path + u'.scss'
     paths = []
     for s in request.registry.settings.get('scss.asset_path').split('\n'):
         if s:
@@ -28,6 +43,7 @@ def _get_asset_path(request):
             paths.append(p)
 
     return paths
+
 
 def _load_asset(request):
     paths = _get_asset_path(request)
@@ -38,3 +54,19 @@ def _load_asset(request):
                 return f.read()
 
     return None
+
+
+class scss_static_view(object):
+    def __init__(self, *args, **kwargs):
+        kwargs['use_subpath'] = True
+        self.static_view = static_view(*args, **kwargs)
+
+    def __call__(self, context, request):
+        try:
+            render = get_renderer('scss')
+            system = dict(request=request)
+            return Response(render(get_scss(context, request), system),
+                            content_type='text/css',
+                            status='200 OK')
+        except HTTPNotFound:
+            return self.static_view(context, request)

--- a/pyramid_scss/tests/__init__.py
+++ b/pyramid_scss/tests/__init__.py
@@ -46,4 +46,5 @@ class DummyRequest(object):
     def __init__(self, registry):
         self.registry = registry
         self.matchdict = {}
+        self.subpath = ()
         self.response = namedtuple('Response', ['content_type'])

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requires = [
 
 setup(
     name='pyramid_scss',
-    version='0.4',
+    version='0.5',
     description="Adds support for SCSS to Pyramid projects",
     long_description="{0}\n\n{1}".format(readme, changes),
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ readme = open(os.path.join(here, 'README.rst'), 'r').read()
 changes = open(os.path.join(here, 'CHANGES.rst'), 'r').read()
 
 requires = [
-    'pyramid',
+    'pyramid>=1.6a2',
     'zope.interface',
     'pyScss>=1.2',
 ]


### PR DESCRIPTION
Adds the ability to serve SCSS stylesheets transparently, from the same endpoint as static CSS assets. This feature is optional and doesn't break existing configurations. @eevee can you CR if you have the time? Thanks
